### PR TITLE
make main.cpp portable

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,9 @@
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #include <iostream>
 #include <cstring>
 #include <unistd.h>
-#include <windows.h>
 #include "functions.h"
 #define PI 3.14159265358979323846
 using namespace std;
@@ -17,8 +19,12 @@ const int dW=4,dH=8;
 //set cursor at start to avoid flickering
 void gotoxy ( short x, short y )
 {
+#ifdef _WIN32
 	COORD coord = {x, y};
 	SetConsoleCursorPosition ( GetStdHandle ( STD_OUTPUT_HANDLE ), coord );
+#else
+	printf("%c[%d;%df",0x1B,y,x);
+#endif
 }
 char palette[]=" .:;~=#OB8%&";
 


### PR DESCRIPTION
include windows.h only if macro "_WIN32", which is defined by a windows c compiler, is present
use ANSI escape sequences on other Linux/Unix