### PR TITLE
Add all source files as executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,14 @@
-cmake_minimum_required (VERSION 3.0)
-project (raytracer VERSION 1.0)
+cmake_minimum_required(VERSION 3.11)
 
-include_directories(src)
+project(raytracer
+  VERSION 1.0.0
+  LANGUAGES CXX)
 
-add_executable(raytracer src/main.cpp
-                         src/functions.cpp
-                         src/camera.cpp)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+
+add_executable(raytracer src/main.cpp src/camera.cpp src/matrix_operations.cpp
+                         src/vector.cpp)
+
+target_include_directories(raytracer PUBLIC src)
+


### PR DESCRIPTION
This is not the best way of doing things but fixes the build
for now. The source requires C++17 standard because it uses
std::clamp in one place. An handrolled clamp can make the code
C++11 compatible.